### PR TITLE
Fixed template cred file typos user/tenancy ids

### DIFF
--- a/examples/oci-open-lz/operating-entities/oe01/oci-credentials.tfvars.json.template
+++ b/examples/oci-open-lz/operating-entities/oe01/oci-credentials.tfvars.json.template
@@ -2,8 +2,8 @@
     "fingerprint": "<PEM key fingerprint>",
     "private_key_path": "<path to the private key that matches the fingerprint above>",
     "region": "<your region>",
-    "tenancy_id": "<tenancy OCID>",
-    "user_id": "<user OCID>",
+    "tenancy_ocid": "<tenancy OCID>",
+    "user_ocid": "<user OCID>",
     "home_region": "<home region>",
     "private_key_password": "<private key pwd>"
 }

--- a/examples/oci-open-lz/shared/oci-credentials.tfvars.json.template
+++ b/examples/oci-open-lz/shared/oci-credentials.tfvars.json.template
@@ -2,8 +2,8 @@
     "fingerprint": "<PEM key fingerprint>",
     "private_key_path": "<path to the private key that matches the fingerprint above>",
     "region": "<your region>",
-    "tenancy_id": "<tenancy OCID>",
-    "user_id": "<user OCID>",
+    "tenancy_ocid": "<tenancy OCID>",
+    "user_ocid": "<user OCID>",
     "home_region": "<home region>",
     "private_key_password": "<private key pwd>"
 }


### PR DESCRIPTION
Hi Jose!,

There were some typos in the user_id/tenancy_id that were not aligned with what the orchestrator expects in the credentials template files. 

Please review, approve & merge when you can.

Rgds.

Pablo