### PR TITLE
OKE workers updates

### DIFF
--- a/gen/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.jsonnet
+++ b/gen/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.jsonnet
@@ -29,6 +29,7 @@
 
                 "node_config_details": {
                     "node_shape"         : "VM.Standard.E5.Flex",
+                    "image"              : "8.10",
 
                     "flex_shape_settings": {
                         "memory"         : 8,

--- a/workload-extensions/oke/simple/multi-stack/oke_workers.auto.tfvars.json
+++ b/workload-extensions/oke/simple/multi-stack/oke_workers.auto.tfvars.json
@@ -29,6 +29,7 @@
 
                 "node_config_details": {
                     "node_shape"         : "VM.Standard.E5.Flex",
+                    "image"              : "8.10",
 
                     "flex_shape_settings": {
                         "memory"         : 8,

--- a/workload-extensions/oke/simple/multi-stack/oke_workers.auto.tfvars.json
+++ b/workload-extensions/oke/simple/multi-stack/oke_workers.auto.tfvars.json
@@ -28,6 +28,7 @@
                 },
 
                 "node_config_details": {
+                    "image"              : "8.10",
                     "node_shape"         : "VM.Standard.E5.Flex",
 
                     "flex_shape_settings": {

--- a/workload-extensions/oke/simple/multi-stack/oke_workers.auto.tfvars.json
+++ b/workload-extensions/oke/simple/multi-stack/oke_workers.auto.tfvars.json
@@ -29,7 +29,6 @@
 
                 "node_config_details": {
                     "node_shape"         : "VM.Standard.E5.Flex",
-                    "image"              : "8.10",
 
                     "flex_shape_settings": {
                         "memory"         : 8,

--- a/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.json
+++ b/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.json
@@ -29,6 +29,7 @@
 
                 "node_config_details": {
                     "node_shape"         : "VM.Standard.E5.Flex",
+                    "image"              : "8.10",
 
                     "flex_shape_settings": {
                         "memory"         : 8,

--- a/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.json
+++ b/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.json
@@ -28,6 +28,7 @@
                 },
 
                 "node_config_details": {
+                    "image"              : "8.10",
                     "node_shape"         : "VM.Standard.E5.Flex",
 
                     "flex_shape_settings": {

--- a/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.json
+++ b/workload-extensions/oke/simple/single-stack/oke_workers.auto.tfvars.json
@@ -29,7 +29,6 @@
 
                 "node_config_details": {
                     "node_shape"         : "VM.Standard.E5.Flex",
-                    "image"              : "8.10",
 
                     "flex_shape_settings": {
                         "memory"         : 8,

--- a/workload-extensions/oke/simple/single-stack/readme.md
+++ b/workload-extensions/oke/simple/single-stack/readme.md
@@ -368,7 +368,7 @@ Edit the JSON file to modify CIDR blocks:
 }
 ```
 
-**Important**: Check [OKE supported versions](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm) before upgrading.
+**Important**: [Check Supported Images, Shapes for Worker Nodes](https://docs.oracle.com/en-us/iaas/Content/ContEng/Reference/contengimagesshapes.htm) and [OKE supported versions](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm) before upgrading.
 
 ### 7.5 Add Custom NSG Rules
 


### PR DESCRIPTION
Update worker node images from OL7 to OL8 following the cluster upgrade to version 1.35.2.