### PR TITLE
OKE overlay network support

### DIFF
--- a/gen/AGENTS.md
+++ b/gen/AGENTS.md
@@ -201,7 +201,12 @@ A landing zone config is a Jsonnet object passed to `landing_zone.libsonnet`:
           network: { vcn: '10.0.96.0/22' },
           extension: {
             type: 'oke_simple',
-            params: { kubernetes_version: 'v1.35.2', services_cidr: '...', api_endpoint_allowed_cidrs: ['...'] },
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '...',
+              api_endpoint_allowed_cidrs: ['...'],
+              cni_type: 'overlay',             // optional; omit for native, or set overlay for Flannel-compatible networking
+            },
           },
         },
       },

--- a/gen/workload-extensions/oke/AGENTS.md
+++ b/gen/workload-extensions/oke/AGENTS.md
@@ -24,17 +24,25 @@ For published OKE deployment investigations, inspect the exact orchestrator tag 
 
 ## Current Repo Contract
 
-- `oke_simple` currently emits `cni_type: 'native'`.
-- The generator creates and wires a dedicated pod subnet in the OKE VCN through `pods_subnet_id`.
+- `oke_simple` supports two network shapes through `config_params.cni_type`: `native` and `overlay`.
+- `cni_type` defaults to `native`.
+- `config_params.cni` is the downstream OKE cluster CNI request. It defaults from `cni_type`: `vcn_native` for native and `flannel` for overlay.
+- Native network shape requires `cni: 'vcn_native'`.
+- Overlay network shape currently requires `cni: 'flannel'`.
+- Do not use `flannel` as a workload-extension `config_params.cni_type`; `cni_type` is the workload-extension network shape and only accepts `native` or `overlay`.
+- For native, the generator creates and wires a dedicated pod subnet in the OKE VCN through `pods_subnet_id`.
+- For overlay, the generator does not emit pod subnet, pod route table, pod security list, pod NSG, worker `pods_subnet_id`, or worker `pods_nsg_ids`.
 - `oke_simple` defaults `worker_image` to `'8.10'`, which the generator emits as `node_config_details.image`.
 - `services_cidr` remains the explicit Kubernetes service CIDR in the repo's standard native examples and is emitted under `options.kubernetes_network_config` in the cluster payload consumed by `cis-oke`.
 - `pods_cidr` is not required for the standard native `oke_simple` path, but if a config explicitly sets it the generator preserves it under `options.kubernetes_network_config` as a passthrough to the downstream `cis-oke` module.
+- For overlay, `pods_cidr` defaults to `10.244.0.0/16` and is emitted under `options.kubernetes_network_config`.
 - Do not make `pods_cidr` mandatory again for the native `oke_simple` path unless the downstream module contract truly requires it.
 
 ## CIDR Planning Rules
 
 - Distinguish OCI VCN/subnet CIDRs from Kubernetes-internal CIDRs.
-- For the current native OKE contract in this repo, pod IPs come from the pod subnet inside the OKE VCN.
+- For the native OKE contract in this repo, pod IPs come from the pod subnet inside the OKE VCN.
+- For the overlay OKE contract in this repo, pod IPs come from the Kubernetes overlay pod CIDR, not from an OCI pod subnet. The overlay `pods_cidr` must not overlap the OKE VCN, subnets, `services_cidr`, routed external networks, or other Kubernetes-internal ranges that must communicate.
 - `services_cidr` must be planned separately and must not overlap the OKE VCN or its subnets.
 - If the landing zone connects to on-premises or other clouds, OCI-routed ranges must not overlap those external networks.
 - Do not present an exact OKE CIDR split as "guaranteed" unless the sizing assumptions are explicit.
@@ -52,4 +60,6 @@ If those assumptions are missing, present the CIDRs as an example or starting po
 
 - If official Oracle docs and the repo contract appear inconsistent, stop and verify the downstream module contract before recommending deployment values.
 - For native OKE questions, do not infer overlay semantics from `pods_cidr` passthrough examples.
+- For overlay OKE questions, do not add or require pod OCI subnets unless the contract changes.
+- When multiple OKE platforms are generated, each OKE VCN route table must reference only gateways in that same VCN for NAT and service gateway routes.
 - When changing the OKE contract, update the generator, fixtures, tests, published JSON, and OKE docs in the same change.

--- a/gen/workload-extensions/oke/simple/oke_builder.libsonnet
+++ b/gen/workload-extensions/oke/simple/oke_builder.libsonnet
@@ -6,7 +6,7 @@
 //     metadata(params):: { default_subnets, subnet_order },
 //     render(params):: { metadata, contributions },
 //   }
-//   params.config_params — {kubernetes_version, services_cidr, api_endpoint_allowed_cidrs, worker_image?, pods_cidr?}
+//   params.config_params — {kubernetes_version, services_cidr, api_endpoint_allowed_cidrs, worker_image?, pods_cidr?, cni_type?, cni?}
 //   params.network       — {vcn: 'cidr', subnets: {name: cidr}}
 //   params.naming        — naming object
 //   params.topology      — platform scope semantics from topology.libsonnet
@@ -20,14 +20,28 @@ local oke_context = import './oke_context.libsonnet';
 
 {
   metadata(params):: {
-    default_subnets: {
-      'control-plane': '/25',
-      'int-lb': '/25',
-      pods: '/23',
-      workers: '/23',
-    },
+    local raw_cni_type =
+      if std.objectHas(params.config_params, 'cni_type') && params.config_params.cni_type != null then
+        params.config_params.cni_type
+      else
+        'native',
+    local cni_type =
+      assert std.type(raw_cni_type) == 'string' :
+        'config_params.cni_type must be a string';
+      assert std.member(['native', 'overlay'], raw_cni_type) :
+        'config_params.cni_type must be one of: native, overlay';
+      raw_cni_type,
+    local is_overlay_network = cni_type == 'overlay',
+    default_subnets:
+      {
+        'control-plane': '/25',
+        'int-lb': '/25',
+        workers: '/23',
+      } + (if is_overlay_network then {} else {
+        pods: '/23',
+      }),
     // Order for auto-subnet allocation (determines CIDR assignment order)
-    subnet_order: ['int-lb', 'control-plane', 'workers', 'pods'],
+    subnet_order: ['int-lb', 'control-plane', 'workers'] + (if is_overlay_network then [] else ['pods']),
   },
 
   render(params)::

--- a/gen/workload-extensions/oke/simple/oke_clusters.libsonnet
+++ b/gen/workload-extensions/oke/simple/oke_clusters.libsonnet
@@ -7,7 +7,7 @@ function(ctx) {
     clusters+: {
       [ctx.cluster_key]: {
         name: ctx.cluster_name,
-        cni_type: 'native',
+        cni_type: ctx.cluster_cni_type,
         is_enhanced: true,
         kubernetes_version: ctx.params.config_params.kubernetes_version,
         networking: {

--- a/gen/workload-extensions/oke/simple/oke_context.libsonnet
+++ b/gen/workload-extensions/oke/simple/oke_context.libsonnet
@@ -46,7 +46,7 @@ local cidrs = import '../../../lib/cidrs.libsonnet';
     else 'nsg_api_6443_%d' % (i + 1);
   local api_endpoint_ingress_rules = {
     [api_endpoint_rule_key(i)]: {
-      description: 'Allow TCP ingress to kube-apiserver from API endpoint source CIDR %s on port 6443. Hub E uses the hub management subnet for private admin access.' % api_endpoint_allowed_cidrs[i],
+      description: 'Allow TCP ingress to kube-apiserver from API endpoint source CIDR %s on port 6443 for private admin access.' % api_endpoint_allowed_cidrs[i],
       protocol: 'TCP',
       dst_port_max: '6443',
       dst_port_min: '6443',
@@ -58,7 +58,7 @@ local cidrs = import '../../../lib/cidrs.libsonnet';
   };
   local api_endpoint_egress_rules = {
     [api_endpoint_rule_key(i)]: {
-      description: 'Allow TCP egress from kube-apiserver to API endpoint source CIDR %s on source port 6443. Hub E uses the hub management subnet for private admin access.' % api_endpoint_allowed_cidrs[i],
+      description: 'Allow TCP egress from kube-apiserver to API endpoint source CIDR %s on source port 6443 for private admin access responses.' % api_endpoint_allowed_cidrs[i],
       protocol: 'TCP',
       dst: api_endpoint_allowed_cidrs[i],
       dst_type: 'CIDR_BLOCK',
@@ -68,11 +68,47 @@ local cidrs = import '../../../lib/cidrs.libsonnet';
     }
     for i in std.range(0, std.length(api_endpoint_allowed_cidrs) - 1)
   };
+  local cni_type =
+    if std.objectHas(params.config_params, 'cni_type') && params.config_params.cni_type != null then
+      assert std.type(params.config_params.cni_type) == 'string' :
+        'config_params.cni_type must be a string';
+      assert std.member(['native', 'overlay'], params.config_params.cni_type) :
+        'config_params.cni_type must be one of: native, overlay';
+      params.config_params.cni_type
+    else
+      'native';
+  local cni =
+    if std.objectHas(params.config_params, 'cni') && params.config_params.cni != null then
+      assert std.type(params.config_params.cni) == 'string' :
+        'config_params.cni must be a string';
+      assert std.member(['vcn_native', 'flannel'], params.config_params.cni) :
+        'config_params.cni must be one of: vcn_native, flannel';
+      params.config_params.cni
+    else if cni_type == 'overlay' then
+      'flannel'
+    else
+      'vcn_native';
+  assert cni_type != 'native' || cni == 'vcn_native' :
+    'config_params.cni_type native requires config_params.cni vcn_native';
+  assert cni_type != 'overlay' || cni == 'flannel' :
+    'config_params.cni_type overlay requires config_params.cni flannel';
+  local is_overlay_network = cni_type == 'overlay';
+  local cluster_cni_type =
+    if cni == 'vcn_native' then 'native'
+    else 'flannel';
   local optional_cluster_kubernetes_network_config =
-    if std.objectHas(params.config_params, 'pods_cidr') && params.config_params.pods_cidr != null then
-      local pods_cidr = cidrs.validate('config_params.pods_cidr', params.config_params.pods_cidr);
+    if is_overlay_network || (std.objectHas(params.config_params, 'pods_cidr') && params.config_params.pods_cidr != null) then
+      local raw_pods_cidr =
+        if std.objectHas(params.config_params, 'pods_cidr') && params.config_params.pods_cidr != null then
+          params.config_params.pods_cidr
+        else
+          '10.244.0.0/16';
+      local pods_cidr = cidrs.validate('config_params.pods_cidr', raw_pods_cidr);
       assert !cidrs.overlaps(pods_cidr, services_cidr) :
-        'config_params.pods_cidr must not overlap config_params.services_cidr';
+        if is_overlay_network then
+          'config_params.pods_cidr for overlay must not overlap config_params.services_cidr'
+        else
+          'config_params.pods_cidr must not overlap config_params.services_cidr';
       { pods_cidr: pods_cidr }
     else
       {};
@@ -118,6 +154,10 @@ local cidrs = import '../../../lib/cidrs.libsonnet';
     services_cidr: services_cidr,
     api_endpoint_ingress_rules: api_endpoint_ingress_rules,
     api_endpoint_egress_rules: api_endpoint_egress_rules,
+    cni_type: cni_type,
+    cni: cni,
+    cluster_cni_type: cluster_cni_type,
+    is_overlay_network: is_overlay_network,
     optional_cluster_kubernetes_network_config: optional_cluster_kubernetes_network_config,
     worker_image: worker_image,
     cluster_key: cluster_key,

--- a/gen/workload-extensions/oke/simple/oke_network.libsonnet
+++ b/gen/workload-extensions/oke/simple/oke_network.libsonnet
@@ -27,7 +27,7 @@ function(ctx, overlay_output=false) {
             is_ipv6enabled: false,
             is_oracle_gua_allocation_enabled: false,
 
-            subnets: {
+            subnets: ({
               [ctx.sn_cp_key]: {
                 display_name: n.display('sn', ctx.display_segments + ['cp']),
                 dns_label: n.dns_label(['sn', ctx.dns, 'plat', ctx.plat, 'cp']),
@@ -50,17 +50,6 @@ function(ctx, overlay_output=false) {
                 security_list_keys: [ctx.sl_lb_key],
               },
 
-              [ctx.sn_pods_key]: {
-                display_name: n.display('sn', ctx.display_segments + ['pods']),
-                dns_label: n.dns_label(['sn', ctx.dns, 'plat', ctx.plat, 'pods']),
-                cidr_block: ctx.subnets.pods,
-                dhcp_options_key: 'default_dhcp_options',
-                prohibit_internet_ingress: true,
-                prohibit_public_ip_on_vnic: true,
-                route_table_key: ctx.rt_pods_key,
-                security_list_keys: [ctx.sl_pods_key],
-              },
-
               [ctx.sn_workers_key]: {
                 display_name: n.display('sn', ctx.display_segments + ['workers']),
                 dns_label: n.dns_label(['sn', ctx.dns, 'plat', ctx.plat, 'work']),
@@ -71,19 +60,31 @@ function(ctx, overlay_output=false) {
                 route_table_key: ctx.rt_workers_key,
                 security_list_keys: [ctx.sl_workers_key],
               },
-            },
+            } + (if ctx.is_overlay_network then {} else {
+              [ctx.sn_pods_key]: {
+                display_name: n.display('sn', ctx.display_segments + ['pods']),
+                dns_label: n.dns_label(['sn', ctx.dns, 'plat', ctx.plat, 'pods']),
+                cidr_block: ctx.subnets.pods,
+                dhcp_options_key: 'default_dhcp_options',
+                prohibit_internet_ingress: true,
+                prohibit_public_ip_on_vnic: true,
+                route_table_key: ctx.rt_pods_key,
+                security_list_keys: [ctx.sl_pods_key],
+              },
+            })),
 
             route_tables: {
               [desc.key]: {
                 display_name: n.display('rt', ctx.display_segments + [desc.suffix]),
-                route_rules: root._route_rules,
+                route_rules: root._route_rules(ctx),
               }
               for desc in [
                 { key: ctx.rt_cp_key, suffix: 'cp' },
                 { key: ctx.rt_lb_key, suffix: 'int-lb' },
-                { key: ctx.rt_pods_key, suffix: 'pods' },
                 { key: ctx.rt_workers_key, suffix: 'workers' },
-              ]
+              ] + (if ctx.is_overlay_network then [] else [
+                { key: ctx.rt_pods_key, suffix: 'pods' },
+              ])
             },
 
             security_lists: {
@@ -111,67 +112,72 @@ function(ctx, overlay_output=false) {
                   extras: { defined_tags: null, freeform_tags: null },
                 },
                 {
-                  key: ctx.sl_pods_key,
-                  suffix: 'pods',
-                  egress: icmp_security_list_egress_rules,
-                  ingress: icmp_security_list_ingress_rules,
-                },
-                {
                   key: ctx.sl_workers_key,
                   suffix: 'workers',
                   egress: icmp_security_list_egress_rules,
                   ingress: icmp_security_list_ingress_rules,
                 },
-              ]
+              ] + (if ctx.is_overlay_network then [] else [
+                {
+                  key: ctx.sl_pods_key,
+                  suffix: 'pods',
+                  egress: icmp_security_list_egress_rules,
+                  ingress: icmp_security_list_ingress_rules,
+                },
+              ])
             },
 
-            network_security_groups: {
+            network_security_groups: ({
               [ctx.nsg_cp_key]: {
                 display_name: n.display('nsg', ctx.display_segments + ['cp']),
 
                 egress_rules: {
                   nsg_cp_6443: root._nsg_tcp_egress('Allow TCP egress for Kubernetes control plane inter-communication', ctx.nsg_cp_key, '6443'),
-                  nsg_pods: root._nsg_tcp_egress_any('Broad webhook rule: allow TCP egress from OKE control plane to pods on any port for API server callbacks. If removed, keep explicit 12250 and 6443 rules.', ctx.nsg_pods_key),
-                  nsg_pods_12250: root._nsg_tcp_egress_src('Allow TCP egress from OKE control plane to pods with source port 12250', ctx.nsg_pods_key, '12250'),
-                  nsg_pods_6443: root._nsg_tcp_egress_src('Allow TCP egress from OKE control plane to pods with source port 6443', ctx.nsg_pods_key, '6443'),
                   nsg_service: root._nsg_service_egress('Allow TCP egress from OKE control plane to OCI services'),
                   nsg_workers_10250: root._nsg_tcp_egress('Allow TCP egress for path discovery to worker nodes', ctx.nsg_workers_key, '10250'),
                   nsg_workers_12250: root._nsg_tcp_egress_src('Allow TCP egress from control plane to worker nodes with source port 12250', ctx.nsg_workers_key, '12250'),
                   nsg_workers_6443: root._nsg_tcp_egress_src('Allow TCP egress from control plane to worker nodes with source port 6443', ctx.nsg_workers_key, '6443'),
-                } + ctx.api_endpoint_egress_rules,
+                } + (if ctx.is_overlay_network then {} else {
+                  nsg_pods: root._nsg_tcp_egress_any('Broad webhook rule: allow TCP egress from OKE control plane to pods on any port for API server callbacks. If removed, keep explicit 12250 and 6443 rules.', ctx.nsg_pods_key),
+                  nsg_pods_12250: root._nsg_tcp_egress_src('Allow TCP egress from OKE control plane to pods with source port 12250', ctx.nsg_pods_key, '12250'),
+                  nsg_pods_6443: root._nsg_tcp_egress_src('Allow TCP egress from OKE control plane to pods with source port 6443', ctx.nsg_pods_key, '6443'),
+                }) + ctx.api_endpoint_egress_rules,
 
                 ingress_rules: {
                   nsg_cp_6443: root._nsg_tcp_ingress_src('Allow TCP ingress for Kubernetes control plane inter-communication on source port 6443', ctx.nsg_cp_key, '6443'),
                 } + ctx.api_endpoint_ingress_rules + {
-                  nsg_pods: root._nsg_tcp_ingress_any('Return pair for broad pod webhook rule: allow TCP ingress from pods to OKE control plane. If broad rule is removed, keep 12250 and 6443 rules.', ctx.nsg_pods_key),
-                  nsg_pods_12250: root._nsg_tcp_ingress('Allow TCP ingress from pods to kube-apiserver on port 12250', ctx.nsg_pods_key, '12250'),
-                  nsg_pods_6443: root._nsg_tcp_ingress('Allow TCP ingress to kube-apiserver from pods on port 6443', ctx.nsg_pods_key, '6443'),
                   nsg_service: root._nsg_service_ingress('Allow TCP ingress from OCI services to control plane for responses'),
                   nsg_workers_10250: root._nsg_tcp_ingress_src('Allow TCP ingress to control plane from worker nodes for Kubelet responses on source port 10250', ctx.nsg_workers_key, '10250'),
                   nsg_workers_12250: root._nsg_tcp_ingress('Allow TCP ingress to kube-apiserver from workers on port 12250', ctx.nsg_workers_key, '12250'),
                   nsg_workers_6443: root._nsg_tcp_ingress('Allow TCP ingress to kube-apiserver from workers on port 6443', ctx.nsg_workers_key, '6443'),
-                },
+                } + (if ctx.is_overlay_network then {} else {
+                  nsg_pods: root._nsg_tcp_ingress_any('Return pair for broad pod webhook rule: allow TCP ingress from pods to OKE control plane. If broad rule is removed, keep 12250 and 6443 rules.', ctx.nsg_pods_key),
+                  nsg_pods_12250: root._nsg_tcp_ingress('Allow TCP ingress from pods to kube-apiserver on port 12250', ctx.nsg_pods_key, '12250'),
+                  nsg_pods_6443: root._nsg_tcp_ingress('Allow TCP ingress to kube-apiserver from pods on port 6443', ctx.nsg_pods_key, '6443'),
+                }),
               },
 
               [ctx.nsg_lb_key]: {
                 display_name: n.display('nsg', ctx.display_segments + ['int-lb', 'default-backend']),
                 ingress_rules: {
-                  nsg_pods_tcp: root._nsg_tcp_ingress_any('Allow TCP ingress from pods to load balancers for responses', ctx.nsg_pods_key),
-                  nsg_pods_udp: root._nsg_udp_ingress_any('Allow UDP ingress from pods to load balancers for responses', ctx.nsg_pods_key),
                   nsg_workers_10256: root._nsg_tcp_ingress_src('Allow TCP ingress from worker nodes to load balancers for health check responses on source port 10256', ctx.nsg_workers_key, '10256'),
                   nsg_workers_tcp: root._nsg_tcp_ingress_src_range('Allow TCP ingress from worker nodes to load balancers for service responses on source ports 30000-32767', ctx.nsg_workers_key, '30000', '32767'),
                   nsg_workers_udp: root._nsg_udp_ingress_src_range('Allow UDP ingress from worker nodes to load balancers for service responses on source ports 30000-32767', ctx.nsg_workers_key, '30000', '32767'),
-                },
+                } + (if ctx.is_overlay_network then {} else {
+                  nsg_pods_tcp: root._nsg_tcp_ingress_any('Allow TCP ingress from pods to load balancers for responses', ctx.nsg_pods_key),
+                  nsg_pods_udp: root._nsg_udp_ingress_any('Allow UDP ingress from pods to load balancers for responses', ctx.nsg_pods_key),
+                }),
 
                 egress_rules: {
-                  nsg_pods_tcp: root._nsg_tcp_egress_any('Allow TCP egress from load balancers to pods for OCI Native Ingress and Pods as Backends', ctx.nsg_pods_key),
-                  nsg_pods_udp: root._nsg_udp_egress_any('Allow UDP egress from load balancers to pods for OCI Native Ingress and Pods as Backends', ctx.nsg_pods_key),
                   nsg_workers_tcp: root._nsg_tcp_egress_range('Allow TCP egress from load balancers to worker nodes for NodePort traffic', ctx.nsg_workers_key, '30000', '32767'),
                   nsg_workers_udp: root._nsg_udp_egress_range('Allow UDP egress from load balancers to worker nodes for NodePort traffic', ctx.nsg_workers_key, '30000', '32767'),
                   nsg_workers_10256: root._nsg_tcp_egress('Allow TCP egress from load balancers to worker nodes for health checks', ctx.nsg_workers_key, '10256'),
-                },
+                } + (if ctx.is_overlay_network then {} else {
+                  nsg_pods_tcp: root._nsg_tcp_egress_any('Allow TCP egress from load balancers to pods for OCI Native Ingress and Pods as Backends', ctx.nsg_pods_key),
+                  nsg_pods_udp: root._nsg_udp_egress_any('Allow UDP egress from load balancers to pods for OCI Native Ingress and Pods as Backends', ctx.nsg_pods_key),
+                }),
               },
-
+            } + (if ctx.is_overlay_network then {} else {
               [ctx.nsg_pods_key]: {
                 display_name: n.display('nsg', ctx.display_segments + ['pods']),
 
@@ -202,7 +208,7 @@ function(ctx, overlay_output=false) {
                   nsg_workers: root._nsg_all_ingress('Allow ALL ingress to pods from workers', ctx.nsg_workers_key),
                 } + root._hub_public_lb_pod_ingress_rules(ctx),
               },
-
+            }) + {
               [ctx.nsg_workers_key]: {
                 display_name: n.display('nsg', ctx.display_segments + ['workers']),
 
@@ -221,10 +227,11 @@ function(ctx, overlay_output=false) {
                   nsg_lb_10256: root._nsg_tcp_egress_src('Allow TCP egress to load balancers from workers with source port 10256', ctx.nsg_lb_key, '10256'),
                   nsg_lb_tcp: root._nsg_tcp_egress_src_range('Allow TCP egress to load balancers from workers with source ports 30000-32767', ctx.nsg_lb_key, '30000', '32767'),
                   nsg_lb_udp: root._nsg_udp_egress_src_range('Allow UDP egress to load balancers from workers with source ports 30000-32767', ctx.nsg_lb_key, '30000', '32767'),
-                  nsg_pods: root._nsg_all_egress('Allow ALL egress from workers to pods', ctx.nsg_pods_key),
                   nsg_service: root._nsg_service_egress('Allow TCP egress from workers to OCI Services'),
                   nsg_workers: root._nsg_all_egress('Allow ALL egress from workers to other workers', ctx.nsg_workers_key),
-                } + root._hub_public_lb_worker_egress_rules(ctx),
+                } + (if ctx.is_overlay_network then {} else {
+                  nsg_pods: root._nsg_all_egress('Allow ALL egress from workers to pods', ctx.nsg_pods_key),
+                }) + root._hub_public_lb_worker_egress_rules(ctx),
 
                 ingress_rules: {
                   nsg_cp: root._nsg_tcp_ingress_any('Broad hostNetwork webhook rule: allow TCP ingress to workers from Kubernetes control plane on any port.', ctx.nsg_cp_key),
@@ -234,12 +241,13 @@ function(ctx, overlay_output=false) {
                   nsg_lb_10256: root._nsg_tcp_ingress('Allow TCP ingress to workers for health check from load balancer on port 10256', ctx.nsg_lb_key, '10256'),
                   nsg_lb_tcp: root._nsg_tcp_ingress_range('Allow TCP ingress to workers from load balancers on service ports 30000-32767', ctx.nsg_lb_key, '30000', '32767'),
                   nsg_lb_udp: root._nsg_udp_ingress_range('Allow UDP ingress to workers from load balancers on service ports 30000-32767', ctx.nsg_lb_key, '30000', '32767'),
-                  nsg_pods: root._nsg_all_ingress('Allow ALL ingress to workers from pods', ctx.nsg_pods_key),
                   nsg_service: root._nsg_service_ingress('Allow TCP ingress from OCI services to workers'),
                   nsg_workers: root._nsg_all_ingress('Allow ALL ingress to workers from other workers', ctx.nsg_workers_key),
-                } + root._hub_public_lb_worker_ingress_rules(ctx),
+                } + (if ctx.is_overlay_network then {} else {
+                  nsg_pods: root._nsg_all_ingress('Allow ALL ingress to workers from pods', ctx.nsg_pods_key),
+                }) + root._hub_public_lb_worker_ingress_rules(ctx),
               },
-            },
+            }),
 
             vcn_specific_gateways:
               {
@@ -249,14 +257,14 @@ function(ctx, overlay_output=false) {
                     services: 'all-services',
                   },
                 },
-              } + if ctx.has_hub && !overlay_output && ctx.use_local_natgw then {
+              } + (if ctx.has_hub && !overlay_output && ctx.use_local_natgw then {
                 nat_gateways: {
                   [ctx.ngw_key]: {
                     display_name: n.display('ngw', ctx.display_segments),
                     block_traffic: false,
                   },
                 },
-              } else {},
+              } else {}),
           },
         },
       },
@@ -649,7 +657,7 @@ function(ctx, overlay_output=false) {
     stateless: true,
   },
 
-  _route_rules::
+  _route_rules(ctx)::
     local peer_routes = if ctx.routing != null && std.objectHas(ctx.routing, 'peers') then ctx.routing.peers else {};
     local drg_route_rules =
       (if ctx.has_hub then {

--- a/gen/workload-extensions/oke/simple/oke_workers.libsonnet
+++ b/gen/workload-extensions/oke/simple/oke_workers.libsonnet
@@ -19,9 +19,10 @@ function(ctx) {
         freeform_tags: {
           cluster: ctx.cluster_name,
         },
-        networking: {
+        networking: (if ctx.is_overlay_network then {} else {
           pods_nsg_ids: [ctx.nsg_pods_key],
           pods_subnet_id: ctx.sn_pods_key,
+        }) + {
           workers_nsg_ids: [ctx.nsg_workers_key],
           workers_subnet_id: ctx.sn_workers_key,
         },

--- a/tests/gen/testdata/configs/fail/platform_extension_invalid_cni.jsonnet
+++ b/tests/gen/testdata/configs/fail/platform_extension_invalid_cni.jsonnet
@@ -1,0 +1,23 @@
+// OKE extension rejects unknown OKE cluster CNI values
+// error_contains: config_params.cni must be one of: vcn_native, flannel
+{
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      platforms: {
+        oke: {
+          network: { vcn: '10.0.80.0/21' },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni: 'cilium',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/gen/testdata/configs/fail/platform_extension_invalid_cni_type.jsonnet
+++ b/tests/gen/testdata/configs/fail/platform_extension_invalid_cni_type.jsonnet
@@ -1,0 +1,23 @@
+// OKE extension rejects unknown network CNI shapes
+// error_contains: config_params.cni_type must be one of: native, overlay
+{
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      platforms: {
+        oke: {
+          network: { vcn: '10.0.80.0/21' },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'vxlan',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/gen/testdata/configs/fail/platform_extension_native_flannel_cni.jsonnet
+++ b/tests/gen/testdata/configs/fail/platform_extension_native_flannel_cni.jsonnet
@@ -1,0 +1,24 @@
+// OKE native network shape cannot request the flannel cluster CNI
+// error_contains: config_params.cni_type native requires config_params.cni vcn_native
+{
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      platforms: {
+        oke: {
+          network: { vcn: '10.0.80.0/21' },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'native',
+              cni: 'flannel',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/gen/testdata/configs/fail/platform_extension_overlay_missing_required_subnet.jsonnet
+++ b/tests/gen/testdata/configs/fail/platform_extension_overlay_missing_required_subnet.jsonnet
@@ -1,0 +1,29 @@
+// OKE overlay subnet overrides must include the worker subnet
+// error_contains: Platform oke.network.subnets for extension oke_simple missing required keys: workers
+{
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      platforms: {
+        oke: {
+          network: {
+            vcn: '10.0.80.0/21',
+            subnets: {
+              'control-plane': '10.0.80.128/25',
+              'int-lb': '10.0.80.0/25',
+            },
+          },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'overlay',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/gen/testdata/configs/fail/platform_extension_overlay_pods_cidr_overlaps_services_cidr.jsonnet
+++ b/tests/gen/testdata/configs/fail/platform_extension_overlay_pods_cidr_overlaps_services_cidr.jsonnet
@@ -1,0 +1,24 @@
+// OKE overlay pod CIDR must not overlap the Kubernetes service CIDR
+// error_contains: config_params.pods_cidr for overlay must not overlap config_params.services_cidr
+{
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      platforms: {
+        oke: {
+          network: { vcn: '10.0.80.0/21' },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              pods_cidr: '10.96.0.0/16',
+              cni_type: 'overlay',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/gen/testdata/configs/fail/platform_extension_overlay_pods_subnet_unsupported.jsonnet
+++ b/tests/gen/testdata/configs/fail/platform_extension_overlay_pods_subnet_unsupported.jsonnet
@@ -1,0 +1,31 @@
+// OKE overlay subnet overrides must not include the native pod subnet
+// error_contains: Platform oke.network.subnets for extension oke_simple has unsupported keys: pods. Allowed: int-lb, control-plane, workers
+{
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      platforms: {
+        oke: {
+          network: {
+            vcn: '10.0.80.0/21',
+            subnets: {
+              'control-plane': '10.0.80.128/25',
+              'int-lb': '10.0.80.0/25',
+              workers: '10.0.81.0/23',
+              pods: '10.0.83.0/23',
+            },
+          },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'overlay',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/gen/testdata/configs/fail/platform_extension_overlay_vcn_native_cni.jsonnet
+++ b/tests/gen/testdata/configs/fail/platform_extension_overlay_vcn_native_cni.jsonnet
@@ -1,0 +1,24 @@
+// OKE overlay network shape cannot request the VCN native cluster CNI
+// error_contains: config_params.cni_type overlay requires config_params.cni flannel
+{
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      platforms: {
+        oke: {
+          network: { vcn: '10.0.80.0/21' },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'overlay',
+              cni: 'vcn_native',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/gen/testdata/direct/pass/config_prod_oke_overlay_output_surface.jsonnet
+++ b/tests/gen/testdata/direct/pass/config_prod_oke_overlay_output_surface.jsonnet
@@ -1,0 +1,60 @@
+// config-mode prod OKE overlay emits flannel-compatible cluster and worker outputs without pod network resources
+local multi = import 'gen/landing_zone_multi.jsonnet';
+local outputs = multi({
+  hub: { kind: 'hub_e', network: { vcn: '10.0.0.0/21' } },
+  environments: {
+    prod: {
+      shared_project_network: { network: { vcn: '10.0.72.0/21' } },
+      projects: { proj1: {} },
+      platforms: {
+        oke: {
+          network: { vcn: '10.0.80.0/21' },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'overlay',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+});
+local clusters = outputs['oke_clusters.json'].oke_clusters_configuration.clusters;
+local cluster_key = std.objectFields(clusters)[0];
+local cluster = clusters[cluster_key];
+local node_pools = outputs['oke_workers.json'].oke_workers_configuration.node_pools;
+local node_pool_key = std.objectFields(node_pools)[0];
+local node_pool = node_pools[node_pool_key];
+local network_category =
+  outputs['network.json'].network_configuration.network_configuration_categories['prod-platform-oke'];
+local vcn = network_category.vcns['VCN-FRA-LZ-PROD-PLATFORM-OKE-KEY'];
+local pod_nsg_key = 'NSG-FRA-LZ-PROD-PLATFORM-OKE-PODS-KEY';
+local nsg_rules(nsg) =
+  [nsg.egress_rules[key] for key in std.objectFields(nsg.egress_rules)] +
+  [nsg.ingress_rules[key] for key in std.objectFields(nsg.ingress_rules)];
+local rule_references_pods(rule) =
+  (std.objectHas(rule, 'src') && rule.src == pod_nsg_key) ||
+  (std.objectHas(rule, 'dst') && rule.dst == pod_nsg_key);
+{
+  cluster_cni_type: cluster.cni_type,
+  kubernetes_network_config: cluster.options.kubernetes_network_config,
+  node_pool_networking: node_pool.networking,
+  oke_subnet_keys: std.sort(std.objectFields(vcn.subnets)),
+  oke_route_table_keys: std.sort(std.objectFields(vcn.route_tables)),
+  oke_security_list_keys: std.sort(std.objectFields(vcn.security_lists)),
+  oke_nsg_keys: std.sort(std.objectFields(vcn.network_security_groups)),
+  pod_nsg_reference_count: std.length([
+    rule
+    for nsg_key in std.objectFields(vcn.network_security_groups)
+    for rule in nsg_rules(vcn.network_security_groups[nsg_key])
+    if rule_references_pods(rule)
+  ]),
+  worker_nsg_rule_keys: {
+    egress: std.sort(std.objectFields(vcn.network_security_groups['NSG-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY'].egress_rules)),
+    ingress: std.sort(std.objectFields(vcn.network_security_groups['NSG-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY'].ingress_rules)),
+  },
+}

--- a/tests/gen/testdata/direct/pass/config_prod_oke_overlay_output_surface.out
+++ b/tests/gen/testdata/direct/pass/config_prod_oke_overlay_output_surface.out
@@ -1,0 +1,65 @@
+{
+  "cluster_cni_type": "flannel",
+  "kubernetes_network_config": {
+    "pods_cidr": "10.244.0.0/16",
+    "services_cidr": "10.96.0.0/16"
+  },
+  "node_pool_networking": {
+    "workers_nsg_ids": [
+      "NSG-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY"
+    ],
+    "workers_subnet_id": "SN-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY"
+  },
+  "oke_nsg_keys": [
+    "NSG-FRA-LZ-PROD-PLATFORM-OKE-CP-KEY",
+    "NSG-FRA-LZ-PROD-PLATFORM-OKE-INT-LB-KEY",
+    "NSG-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY"
+  ],
+  "oke_route_table_keys": [
+    "RT-FRA-LZ-PROD-PLATFORM-OKE-CP-KEY",
+    "RT-FRA-LZ-PROD-PLATFORM-OKE-INT-LB-KEY",
+    "RT-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY"
+  ],
+  "oke_security_list_keys": [
+    "SL-FRA-LZ-PROD-PLATFORM-OKE-CP-KEY",
+    "SL-FRA-LZ-PROD-PLATFORM-OKE-INT-LB-KEY",
+    "SL-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY"
+  ],
+  "oke_subnet_keys": [
+    "SN-FRA-LZ-PROD-PLATFORM-OKE-CP-KEY",
+    "SN-FRA-LZ-PROD-PLATFORM-OKE-INT-LB-KEY",
+    "SN-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY"
+  ],
+  "pod_nsg_reference_count": 0,
+  "worker_nsg_rule_keys": {
+    "egress": [
+      "anywhere",
+      "hub_public_lb_10256",
+      "hub_public_lb_tcp",
+      "hub_public_lb_udp",
+      "nsg_cp",
+      "nsg_cp_10250",
+      "nsg_cp_12250",
+      "nsg_cp_6443",
+      "nsg_lb_10256",
+      "nsg_lb_tcp",
+      "nsg_lb_udp",
+      "nsg_service",
+      "nsg_workers"
+    ],
+    "ingress": [
+      "hub_public_lb_10256",
+      "hub_public_lb_tcp",
+      "hub_public_lb_udp",
+      "nsg_cp",
+      "nsg_cp_10250",
+      "nsg_cp_12250",
+      "nsg_cp_6443",
+      "nsg_lb_10256",
+      "nsg_lb_tcp",
+      "nsg_lb_udp",
+      "nsg_service",
+      "nsg_workers"
+    ]
+  }
+}

--- a/tests/gen/testdata/direct/pass/oke_security_lists_icmp_lockdown.jsonnet
+++ b/tests/gen/testdata/direct/pass/oke_security_lists_icmp_lockdown.jsonnet
@@ -1,0 +1,75 @@
+// OKE subnet security lists stay aligned with the stateless ICMP lockdown pattern
+local expected_pmtu_egress = {
+  description: 'Required to enable Path MTU Discovery responses to work, and non-OCI communication',
+  protocol: 'ICMP',
+  dst: '0.0.0.0/0',
+  dst_type: 'CIDR_BLOCK',
+  icmp_code: 4,
+  icmp_type: 3,
+  stateless: true,
+};
+local expected_pmtu_ingress = {
+  description: 'Required to enable Path MTU Discovery to work, and non-OCI communication',
+  protocol: 'ICMP',
+  icmp_code: 4,
+  icmp_type: 3,
+  src: '0.0.0.0/0',
+  src_type: 'CIDR_BLOCK',
+  stateless: true,
+};
+local expected_fail_fast_egress(vcn_cidr) = {
+  description: 'Required to allow application within VCN responses to fail fast',
+  protocol: 'ICMP',
+  dst: vcn_cidr,
+  dst_type: 'CIDR_BLOCK',
+  icmp_type: 3,
+  stateless: true,
+};
+local expected_fail_fast_ingress(vcn_cidr) = {
+  description: 'Required to allow application within VCN to fail fast',
+  protocol: 'ICMP',
+  icmp_type: 3,
+  src: vcn_cidr,
+  src_type: 'CIDR_BLOCK',
+  stateless: true,
+};
+local icmp_rule_count(rules) =
+  std.length([rule for rule in rules if rule.protocol == 'ICMP']);
+local list_has_rule(rules, expected) =
+  std.length([rule for rule in rules if rule == expected]) == 1;
+local summarize_security_list(vcn_cidr, sl) =
+  local egress = sl.egress_rules;
+  local ingress = sl.ingress_rules;
+  {
+    egress_icmp_rule_count: icmp_rule_count(egress),
+    ingress_icmp_rule_count: icmp_rule_count(ingress),
+    has_fail_fast_egress: list_has_rule(egress, expected_fail_fast_egress(vcn_cidr)),
+    has_fail_fast_ingress: list_has_rule(ingress, expected_fail_fast_ingress(vcn_cidr)),
+    has_pmtu_egress: list_has_rule(egress, expected_pmtu_egress),
+    has_pmtu_ingress: list_has_rule(ingress, expected_pmtu_ingress),
+  };
+local summarize(payload) =
+  local categories = payload.network_configuration.network_configuration_categories;
+  {
+    [category_key]: {
+      [vcn_key]:
+        local vcn = categories[category_key].vcns[vcn_key];
+        local vcn_cidr = vcn.cidr_blocks[0];
+        {
+          default_security_list: vcn.default_security_list,
+          security_lists: {
+            [sl_key]: summarize_security_list(vcn_cidr, vcn.security_lists[sl_key])
+            for sl_key in std.objectFields(vcn.security_lists)
+          },
+        }
+      for vcn_key in std.objectFields(categories[category_key].vcns)
+    }
+    for category_key in std.objectFields(categories)
+    if std.length(std.findSubstr('platform-oke', category_key)) > 0
+  };
+{
+  multi_stack:
+    summarize(import 'gen/workload-extensions/oke/simple/multi-stack/oke_network.jsonnet'),
+  single_stack:
+    summarize(import 'gen/workload-extensions/oke/simple/single-stack/oke_network.jsonnet'),
+}

--- a/tests/gen/testdata/direct/pass/oke_security_lists_icmp_lockdown.out
+++ b/tests/gen/testdata/direct/pass/oke_security_lists_icmp_lockdown.out
@@ -1,0 +1,90 @@
+{
+  "multi_stack": {
+    "prod-platform-oke": {
+      "VCN-FRA-LZ-PROD-PLATFORM-OKE-KEY": {
+        "default_security_list": {
+          "egress_rules": [],
+          "ingress_rules": []
+        },
+        "security_lists": {
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-CP-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          },
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-INT-LB-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          },
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-PODS-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          },
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          }
+        }
+      }
+    }
+  },
+  "single_stack": {
+    "prod-platform-oke": {
+      "VCN-FRA-LZ-PROD-PLATFORM-OKE-KEY": {
+        "default_security_list": {
+          "egress_rules": [],
+          "ingress_rules": []
+        },
+        "security_lists": {
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-CP-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          },
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-INT-LB-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          },
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-PODS-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          },
+          "SL-FRA-LZ-PROD-PLATFORM-OKE-WORKERS-KEY": {
+            "egress_icmp_rule_count": 2,
+            "has_fail_fast_egress": true,
+            "has_fail_fast_ingress": true,
+            "has_pmtu_egress": true,
+            "has_pmtu_ingress": true,
+            "ingress_icmp_rule_count": 2
+          }
+        }
+      }
+    }
+  }
+}

--- a/workload-extensions/oke/readme.md
+++ b/workload-extensions/oke/readme.md
@@ -10,7 +10,7 @@ The OKE Landing Zone Extension is a secure cloud environment, designed with the 
 
 Currently two options are available
 
-- [**Simple OKE deployment**](./simple) - 1 OKE Cluster in production environment using a simple configuration.
+- [**Simple OKE deployment**](./simple) - 1 OKE Cluster in production environment using a simple published configuration. Config-driven generation can customize the simple pattern, including native or overlay OKE networking.
 - [**Advanced OKE deployment**](./advanced) - 3 OKE Clusters in prod, pre-prod and management environments using an advanced configuration. 
 
 &nbsp;

--- a/workload-extensions/oke/simple/config-driven.md
+++ b/workload-extensions/oke/simple/config-driven.md
@@ -1,0 +1,226 @@
+# OKE Config-Driven Generation <!-- omit from toc -->
+
+- [**1. Overview**](#1-overview)
+- [**2. Prerequisites**](#2-prerequisites)
+- [**3. What `oke_simple` Means**](#3-what-oke_simple-means)
+- [**4. Native OKE Example**](#4-native-oke-example)
+- [**5. Overlay OKE Example**](#5-overlay-oke-example)
+- [**6. Generate the JSON Files**](#6-generate-the-json-files)
+- [**7. Review the Output**](#7-review-the-output)
+
+## **1. Overview**
+
+Use config-driven generation when the published OKE JSON files do not match the landing zone you need. This is useful when you need custom CIDR ranges, multiple environments, more than one OKE cluster, or overlay networking.
+
+The OKE simple workload extension is configured as a platform extension named `oke_simple`. It can generate two OKE network modes:
+
+| Mode | Configuration | Result |
+| --- | --- | --- |
+| Native | Omit `cni_type`, or set `cni_type: 'native'` and `cni: 'vcn_native'` | Creates control plane, internal load balancer, worker, and pod subnets. |
+| Overlay | Set `cni_type: 'overlay'` and `cni: 'flannel'` | Creates control plane, internal load balancer, and worker subnets. Pod addressing uses the Kubernetes overlay pod CIDR. |
+
+For overlay clusters, the requested OKE CNI is Flannel. In the workload-extension configuration, do not set `cni_type` to `flannel`; use `cni_type: 'overlay'`.
+
+## **2. Prerequisites**
+
+Before generating the files:
+
+- Clone this repository locally.
+- Install a Jsonnet renderer on your `PATH`. The standard `jsonnet` command works; `jrsonnet` can also be used for faster local generation.
+- Decide the output directory where the generated JSON files should be written.
+- Confirm the CIDR plan for the hub, any project VCNs, OKE VCNs, Kubernetes services, and, for overlay, Kubernetes pods.
+
+## **3. What `oke_simple` Means**
+
+`oke_simple` is the OKE workload extension type used by config-driven generation. When a platform uses `extension.type: 'oke_simple'`, the generator adds the OKE network, IAM, cluster, worker, security, and observability JSON needed for that platform.
+
+This is different from the published deployment folders:
+
+| Option | What it is | When to use it |
+| --- | --- | --- |
+| `oke_simple` | The config-driven OKE extension type. | Use this when generating a customized landing zone from a configuration file. |
+| `simple/single-stack` | A published OKE JSON package that deploys the landing zone and OKE together. | Use this for the standard Hub E single-stack deployment. |
+| `simple/multi-stack` | A published OKE JSON package that adds OKE to an existing landing zone. | Use this for the standard multi-stack deployment path. |
+| `advanced` | A separate guided deployment path with more manual steps. | Use this only when following the advanced OKE extension documentation. |
+
+In config-driven generation, use `oke_simple` for OKE platforms.
+
+## **4. Native OKE Example**
+
+The following example creates a One-OE landing zone with Hub E and one native OKE cluster in the `prod` environment.
+
+Create a configuration file, for example `oke-native.jsonnet`:
+
+```jsonnet
+{
+  region: 'eu-frankfurt-1',
+  region_short_name: 'fra',
+  realm: 'oc1',
+  hub: {
+    kind: 'hub_e',
+    network: {
+      vcn: '10.0.0.0/21',
+    },
+  },
+  environments: {
+    prod: {
+      shared_project_network: {
+        network: {
+          vcn: '10.0.72.0/21',
+        },
+      },
+      projects: {
+        proj1: {},
+      },
+      platforms: {
+        oke: {
+          network: {
+            vcn: '10.0.80.0/21',
+          },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'native',
+              cni: 'vcn_native',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Native mode is the default. It creates an OCI pod subnet and wires the worker node pool with pod subnet and pod NSG references.
+
+## **5. Overlay OKE Example**
+
+The following example creates a Hub A landing zone with overlay OKE clusters in `prod` and `preprod`.
+
+Create a configuration file, for example `oke-overlay-hub-a.jsonnet`:
+
+```jsonnet
+{
+  region: 'eu-frankfurt-1',
+  region_short_name: 'fra',
+  realm: 'oc1',
+  hub: {
+    kind: 'hub_a',
+    network: {
+      vcn: '10.0.0.0/21',
+    },
+  },
+  environments: {
+    prod: {
+      shared_project_network: {
+        network: {
+          vcn: '10.0.64.0/21',
+        },
+      },
+      projects: {
+        proj1: {},
+      },
+      platforms: {
+        oke: {
+          network: {
+            vcn: '10.0.80.0/21',
+          },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.96.0.0/16',
+              cni_type: 'overlay',
+              cni: 'flannel',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+    preprod: {
+      shared_project_network: {
+        network: {
+          vcn: '10.0.128.0/21',
+        },
+      },
+      projects: {
+        proj1: {},
+      },
+      platforms: {
+        oke: {
+          network: {
+            vcn: '10.0.144.0/21',
+          },
+          extension: {
+            type: 'oke_simple',
+            params: {
+              kubernetes_version: 'v1.35.2',
+              services_cidr: '10.97.0.0/16',
+              cni_type: 'overlay',
+              cni: 'flannel',
+              api_endpoint_allowed_cidrs: ['10.0.1.0/24'],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Overlay mode omits the OCI pod subnet, pod route table, pod security list, pod NSG, and worker pod networking references. If `pods_cidr` is not provided, it defaults to `10.244.0.0/16`.
+
+## **6. Generate the JSON Files**
+
+Run the generator from the repository root:
+
+```bash
+bash gen/generate.sh --config /path/to/oke-config.jsonnet /path/to/generated-oke
+```
+
+Example:
+
+```bash
+bash gen/generate.sh --config ./oke-overlay-hub-a.jsonnet ./generated/oke-overlay-hub-a
+```
+
+The generated directory contains the JSON files to use with the OCI Landing Zone Orchestrator.
+
+## **7. Review the Output**
+
+The generated file set commonly includes:
+
+| File | Purpose |
+| --- | --- |
+| `network.json` | Hub, spoke, platform, OKE VCNs, subnets, route tables, gateways, security lists, and NSGs. |
+| `iam.json` | Compartments, groups, and policies. |
+| `governance.json` | Tag namespaces and governance configuration. |
+| `oke_clusters.json` | OKE cluster configuration. |
+| `oke_workers.json` | OKE node pool configuration. |
+| `security_cis*.json` | Security baseline configuration. |
+| `observability_cis*.json` | Observability baseline configuration. |
+
+Some hub models, including Hub A, also generate `network_pre.json`. This file is used for staged network deployment before the final `network.json`.
+
+For native OKE, check that the worker node pool includes `pods_subnet_id` and `pods_nsg_ids`.
+
+For overlay OKE, check that:
+
+- `oke_clusters.json` requests Flannel in the downstream OKE cluster configuration.
+- `oke_clusters.json` contains `pods_cidr` and `services_cidr`.
+- `oke_workers.json` does not contain `pods_subnet_id` or `pods_nsg_ids`.
+- `network.json` does not contain an OKE pod subnet, pod route table, pod security list, or pod NSG.
+
+&nbsp;
+
+# License <!-- omit from toc -->
+
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+Licensed under the Universal Permissive License (UPL), Version 1.0.
+
+See [LICENSE](/LICENSE.txt) for more details.

--- a/workload-extensions/oke/simple/multi-stack/oke_network.json
+++ b/workload-extensions/oke/simple/multi-stack/oke_network.json
@@ -390,7 +390,7 @@
 
                                 "ingress_rules": {
                                     "nsg_api_6443": {
-                                        "description"                 : "Allow TCP ingress to kube-apiserver from API endpoint source CIDR 10.0.1.0/24 on port 6443. Hub E uses the hub management subnet for private admin access.",
+                                        "description"                 : "Allow TCP ingress to kube-apiserver from API endpoint source CIDR 10.0.1.0/24 on port 6443 for private admin access.",
                                         "src"                         : "10.0.1.0/24",
                                         "src_type"                    : "CIDR_BLOCK",
                                         "dst_port_min"                : "6443",
@@ -478,7 +478,7 @@
 
                                 "egress_rules": {
                                     "nsg_api_6443": {
-                                        "description"                 : "Allow TCP egress from kube-apiserver to API endpoint source CIDR 10.0.1.0/24 on source port 6443. Hub E uses the hub management subnet for private admin access.",
+                                        "description"                 : "Allow TCP egress from kube-apiserver to API endpoint source CIDR 10.0.1.0/24 on source port 6443 for private admin access responses.",
                                         "src_port_min"                : "6443",
                                         "src_port_max"                : "6443",
                                         "dst"                         : "10.0.1.0/24",

--- a/workload-extensions/oke/simple/multi-stack/readme.md
+++ b/workload-extensions/oke/simple/multi-stack/readme.md
@@ -23,6 +23,8 @@
 | **TARGET RESOURCES** | IAM (Compartments, Groups, Policies), Network (VCN, Subnets, NSGs, Gateways), OKE Cluster |
 | **DEPLOYMENT**          | Use the JSON files in this folder with Terraform CLI, or stage them in a customer-controlled private source for OCI Resource Manager as described in [Deployment Steps](#4-deployment-steps). [Terraform CLI](/commons/content/terraform.md) can also be used. |
 
+For customized OKE landing zones generated from a configuration file, see [OKE Config-Driven Generation](../config-driven.md).
+
 
 &nbsp;
 
@@ -33,7 +35,7 @@ This deployment uses the [OCI Landing Zone Orchestrator](https://github.com/oci-
 **Key Features:**
 - **Automated Dependency Resolution**: Network resources (VCN, subnets, NSGs) are automatically linked to the OKE cluster using configuration keys using dependency exchange across stacks
 - **CIS-Compliant**: Uses the CIS-compliant OKE module from [terraform-oci-modules-workloads](https://github.com/oci-landing-zones/terraform-oci-modules-workloads/tree/main/cis-oke)
-- **Native Pod Networking**: Configured with VCN-native pod networking for improved security and performance
+- **OKE Network Modes**: Published JSON is VCN-native by default; config-driven generation can also emit an overlay network shape for Flannel-compatible clusters
 - **Multi-Step Deployment**: Deploy OKE together in one ORM stack and Landing Zone separately
 
 &nbsp;
@@ -183,8 +185,22 @@ Edit `oke_clusters.json`:
 
 - **Kubernetes Version**: Change `kubernetes_version` to upgrade/downgrade
 - **Cluster Type**: Set `is_enhanced: false` for basic clusters
-- **Network CIDRs**: Adjust the OKE VCN/subnet CIDRs and `options.kubernetes_network_config.services_cidr` for your networking requirements. If you intentionally need to pass `pods_cidr`, set it under `options.kubernetes_network_config.pods_cidr`.
+- **Network CIDRs**: Adjust the OKE VCN/subnet CIDRs and `options.kubernetes_network_config.services_cidr` for your networking requirements. In native mode, `pods_cidr` is optional passthrough. In overlay mode, `pods_cidr` represents the Kubernetes overlay pod range and defaults to `10.244.0.0/16` when omitted.
+- **CNI Mode**: The published multi-stack JSON uses native networking. In config-driven generation, set workload-extension `cni_type: overlay` to select the overlay network shape; the OKE CNI is selected with `cni: flannel`.
 - **Security**: Modify `is_api_endpoint_public` and NSG settings
+
+### Native and Overlay Network Modes <!-- omit from toc -->
+
+Config-driven `oke_simple` generation supports two OKE network shapes:
+
+| Config parameter | Purpose | Supported values | Default |
+| --- | --- | --- | --- |
+| `cni_type` | Network shape emitted by this workload extension | `native`, `overlay` | `native` |
+| `cni` | OKE cluster CNI requested from the downstream OKE module | `vcn_native`, `flannel` | `vcn_native` for native, `flannel` for overlay |
+
+Native mode creates control plane, internal load balancer, worker, and pod subnets, plus pod route table, pod security list, pod NSG, and worker pod networking references.
+
+Overlay mode creates only control plane, internal load balancer, and worker subnets. It omits the pod subnet and related pod network resources because pod addressing comes from the Kubernetes overlay pod CIDR. Do not set workload-extension `cni_type` to `flannel`; `flannel` is the OKE CNI value, while `overlay` is the workload-extension network shape.
 
 ### Worker Pool Configuration <!-- omit from toc -->
 
@@ -240,7 +256,8 @@ terraform destroy
 
 **Issue**: Cluster creation fails
 - **Solution**: Check IAM policies are correctly configured
-- Verify VCN-native CNI policy grants required permissions (see `oke_identity.json`)
+- For native clusters, verify VCN-native CNI policy grants required permissions (see `oke_identity.json`)
+- For overlay clusters, verify the source config uses workload-extension `cni_type: overlay` and `cni: flannel`, and that the generated worker node pool does not include `pods_subnet_id` or `pods_nsg_ids`
 
 **Issue**: Nodes not joining cluster
 - **Solution**: Verify NSG rules allow required traffic
@@ -258,6 +275,7 @@ terraform destroy
 - [CIS OKE Module Documentation](https://github.com/oci-landing-zones/terraform-oci-modules-workloads/tree/main/cis-oke)
 - [OKE Documentation](https://docs.oracle.com/en-us/iaas/Content/ContEng/home.htm)
 - [VCN-Native Pod Networking](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking_topic-OCI_CNI_plugin.htm)
+- [Flannel Pod Networking](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking_topic-flannel_CNI_plugin.htm)
 
 &nbsp;
 

--- a/workload-extensions/oke/simple/readme.md
+++ b/workload-extensions/oke/simple/readme.md
@@ -18,6 +18,8 @@ This workload extension uses the [One-OE](https://github.com/oracle-quickstart/t
 
 This OKE Landing Zone Extension provides **two deployment approaches**, [single-stack](single-stack/) and  [multi-stack](multi-stack/), to accommodate different use cases and architectural preferences. Both approaches use the [OCI Landing Zone Orchestrator](https://github.com/oci-landing-zones/terraform-oci-modules-orchestrator) for automated dependency resolution with configuration keys.
 
+For customized OKE landing zones generated from a configuration file, see [OKE Config-Driven Generation](config-driven.md).
+
 
 ### **Choosing the Right Approach**
 
@@ -38,17 +40,28 @@ This OKE Landing Zone Extension provides **two deployment approaches**, [single-
 Both deployment options provide:
 - **Automated Dependency Resolution**: Configuration keys instead of manual OCID lookups
 - **CIS-Compliant OKE**: Using [CIS OKE module](https://github.com/oci-landing-zones/terraform-oci-modules-workloads/tree/main/cis-oke)
-- **VCN-Native Pod Networking**: Improved performance and security
-- **Comprehensive NSG Configuration**: Control plane, workers, pods, and load balancer isolation
+- **OKE CNI Network Modes**: VCN-native pod networking by default, with config-driven overlay networking for Flannel-compatible clusters
+- **Comprehensive NSG Configuration**: Control plane, workers, load balancers, and, for native networking, pods
 - **Hub-and-Spoke Topology**: OKE VCN as spoke connected to Hub via DRG
 - **Service Gateway**: Direct connectivity to OCI services
+
+### OKE Network Modes
+
+The published simple OKE JSON files use the native network mode by default. In config-driven generation, `oke_simple` can also emit an overlay network shape for Flannel-compatible clusters.
+
+| Config parameter | Purpose | Supported values | Default |
+| --- | --- | --- | --- |
+| `cni_type` | Network shape emitted by the workload extension | `native`, `overlay` | `native` |
+| `cni` | OKE cluster CNI requested from the downstream OKE module | `vcn_native`, `flannel` | `vcn_native` for native, `flannel` for overlay |
+
+Native mode emits control plane, internal load balancer, worker, and pod subnets, and wires the worker node pool with pod subnet and pod NSG IDs. Overlay mode emits only control plane, internal load balancer, and worker subnets; it omits the OCI pod subnet, pod route table, pod security list, pod NSG, and worker pod networking fields. Overlay mode defaults `pods_cidr` to `10.244.0.0/16` for the Kubernetes overlay network.
 
 ### Deployment Components
 
 Both approaches deploy these resources:
 - **IAM Configuration**: Compartments, groups, and policies for OKE
 - **Network Infrastructure**: VCN, subnets, NSGs, route tables, service gateway, and DRG attachment
-- **OKE Cluster**: Kubernetes cluster with native pod networking (v1.35.2)
+- **OKE Cluster**: Kubernetes cluster with native or overlay networking (v1.35.2)
 - **Worker Nodes**: Compute instances for running workloads (VM.Standard.E5.Flex, Oracle Linux 8.10)
 
 &nbsp;

--- a/workload-extensions/oke/simple/single-stack/oke_network.json
+++ b/workload-extensions/oke/simple/single-stack/oke_network.json
@@ -1586,7 +1586,7 @@
 
                                 "ingress_rules": {
                                     "nsg_api_6443": {
-                                        "description"                         : "Allow TCP ingress to kube-apiserver from API endpoint source CIDR 10.0.1.0/24 on port 6443. Hub E uses the hub management subnet for private admin access.",
+                                        "description"                         : "Allow TCP ingress to kube-apiserver from API endpoint source CIDR 10.0.1.0/24 on port 6443 for private admin access.",
                                         "src"                                 : "10.0.1.0/24",
                                         "src_type"                            : "CIDR_BLOCK",
                                         "dst_port_min"                        : "6443",
@@ -1674,7 +1674,7 @@
 
                                 "egress_rules": {
                                     "nsg_api_6443": {
-                                        "description"                         : "Allow TCP egress from kube-apiserver to API endpoint source CIDR 10.0.1.0/24 on source port 6443. Hub E uses the hub management subnet for private admin access.",
+                                        "description"                         : "Allow TCP egress from kube-apiserver to API endpoint source CIDR 10.0.1.0/24 on source port 6443 for private admin access responses.",
                                         "src_port_min"                        : "6443",
                                         "src_port_max"                        : "6443",
                                         "dst"                                 : "10.0.1.0/24",

--- a/workload-extensions/oke/simple/single-stack/readme.md
+++ b/workload-extensions/oke/simple/single-stack/readme.md
@@ -32,6 +32,8 @@
 | **TARGET RESOURCES** | Complete LZ Foundation, IAM, Hub Network, DRG, OKE VCN, OKE Cluster with all components integrated |
 | **DEPLOYMENT**          | Use the JSON files in this folder with Terraform CLI, or stage them in a customer-controlled private source for OCI Resource Manager as described in [Deployment Steps](#5-deployment-steps). [Terraform CLI](/commons/content/terraform.md) can also be used. |
 
+For customized OKE landing zones generated from a configuration file, see [OKE Config-Driven Generation](../config-driven.md).
+
 
 &nbsp;
 
@@ -53,7 +55,7 @@ This deployment combines **OneOE Blueprint**, **Hub Model E networking**, and **
 - **Automated Routing**: Hub route tables pre-configured  with OKE CIDR (10.0.80.0/21)
 - **DRG Integration**: Dynamic Routing Gateway with route distributions configured for Hub-Spoke communication
 - **CIS-Compliant OKE**: Uses the CIS-compliant OKE module from [terraform-oci-modules-workloads](https://github.com/oci-landing-zones/terraform-oci-modules-workloads/tree/main/cis-oke)
-- **Native Pod Networking**: Configured with VCN-native pod networking for improved security and performance
+- **OKE Network Modes**: Published JSON is VCN-native by default; config-driven generation can also emit an overlay network shape for Flannel-compatible clusters
 
 &nbsp;
 
@@ -78,7 +80,7 @@ The deployment includes the complete OneOE blueprint with:
 
 ### **3.3 OKE Spoke Network** <!-- omit from toc -->
 
-**OKE VCN (`10.0.80.0/21`)** with four dedicated subnets:
+**OKE VCN (`10.0.80.0/21`)** with dedicated subnets. The published single-stack JSON uses native networking and includes four subnets:
 
 | Subnet | CIDR | Purpose | Size |
 |--------|------|---------|------|
@@ -92,6 +94,8 @@ The deployment includes the complete OneOE blueprint with:
 - NSG for Worker Nodes (full egress, selective ingress)
 - NSG for Pods (pod-to-pod, pod-to-services)
 - NSG for Internal Load Balancers (NodePort range)
+
+For config-driven overlay generation, the OKE VCN uses only the Control Plane, Internal LB, and Worker Nodes subnets. The pod subnet, pod route table, pod security list, pod NSG, and worker pod networking fields are omitted because pod addressing comes from the Kubernetes overlay pod CIDR instead of an OCI pod subnet.
 
 **Gateways:**
 - NAT Gateway for outbound internet access (all subnets)
@@ -110,12 +114,25 @@ The deployment includes the complete OneOE blueprint with:
 ### **3.5 OKE Cluster** <!-- omit from toc -->
 
 - **Kubernetes Version**: v1.35.2
-- **Cluster Type**: Enhanced cluster with native pod networking
+- **Cluster Type**: Enhanced cluster
 - **Control Plane**: Private endpoint in dedicated subnet
 - **Worker Pool**: 1x VM.Standard.E5.Flex (1 OCPU, 8GB RAM, Oracle Linux 8.10) - easily scalable
-- **CNI**: VCN-native pod networking (OCI VCN-Native Pod Networking CNI)
+- **CNI**: VCN-native pod networking in the published JSON; config-driven overlay generation requests Flannel
 
 &nbsp;
+
+### **3.6 Native and Overlay Network Modes** <!-- omit from toc -->
+
+`oke_simple` separates the network shape emitted by the workload extension from the cluster CNI requested from the downstream OKE module.
+
+| Config parameter | Purpose | Supported values | Default |
+| --- | --- | --- | --- |
+| `cni_type` | Network shape emitted by this workload extension | `native`, `overlay` | `native` |
+| `cni` | OKE cluster CNI requested from the downstream OKE module | `vcn_native`, `flannel` | `vcn_native` for native, `flannel` for overlay |
+
+Native mode uses workload-extension `cni_type: native` and `cni: vcn_native`. It creates a pod subnet in the OKE VCN, creates the pod security list and pod NSG, and wires the worker node pool with `pods_subnet_id` and `pods_nsg_ids`.
+
+Overlay mode uses workload-extension `cni_type: overlay` and `cni: flannel`. It creates no OCI pod subnet and wires the worker node pool only with the worker subnet and worker NSG. Overlay mode defaults `pods_cidr` to `10.244.0.0/16`. Keep `services_cidr` and overlay `pods_cidr` non-overlapping with each other, the OKE VCN, and any routed on-premises, cloud, or peered ranges. Do not set workload-extension `cni_type` to `flannel`; `flannel` is the OKE CNI value, while `overlay` is the workload-extension network shape.
 
 ## **4. Configuration Files**
 
@@ -397,6 +414,8 @@ Edit the JSON file to modify CIDR blocks:
 
 **Note**: Keep `options.kubernetes_network_config.services_cidr` aligned with your Kubernetes service network plan. It remains required for the published native OKE payload even though `pods_cidr` is no longer part of the standard single-stack example.
 
+For config-driven overlay clusters, `options.kubernetes_network_config` includes both `services_cidr` and `pods_cidr`. If `pods_cidr` is not provided, the generator defaults it to `10.244.0.0/16`.
+
 **Important**: [Check Supported Images, Shapes for Worker Nodes](https://docs.oracle.com/en-us/iaas/Content/ContEng/Reference/contengimagesshapes.htm) and [OKE supported versions](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm) before upgrading.
 
 ### 7.5 Add Custom NSG Rules
@@ -438,7 +457,7 @@ Understanding the routing is critical for troubleshooting connectivity. This dep
 
 ### 8.1 OKE Subnet Route Tables <!-- omit from toc -->
 
-All four OKE subnets (Control Plane, Internal LB, Workers, Pods) use the same routing pattern:
+The published native OKE subnets (Control Plane, Internal LB, Workers, Pods) use the same routing pattern. Config-driven overlay clusters use the same pattern for the remaining Control Plane, Internal LB, and Workers subnets, with no pod subnet route table.
 
 ```
 Default Route:
@@ -540,8 +559,9 @@ OKE VCN Route:
    ```
    PCY-LZ-PROD-PLATFORM-OKE-VCN-CNI-KEY
    ```
-3. Verify subnet CIDRs don't overlap
-4. Check NSG rules allow required traffic
+3. If using overlay, verify the source config uses workload-extension `cni_type: overlay` and `cni: flannel`, and that the generated worker node pool does not include `pods_subnet_id` or `pods_nsg_ids`
+4. Verify subnet CIDRs don't overlap
+5. Check NSG rules allow required traffic
 
 ### Issue: Worker Nodes Not Joining Cluster <!-- omit from toc -->
 
@@ -572,14 +592,15 @@ OKE VCN Route:
 **Cause**: Pods don't have internet connectivity.
 
 **Solution**:
-1. Verify service gateway route exists in pod subnet route table
-2. Check NSG rules allow egress from pods:
+1. For native clusters, verify service gateway route exists in the pod subnet route table
+2. For overlay clusters, verify the worker subnet route table has service gateway and NAT/default routes because pod traffic exits through worker nodes
+3. Check NSG rules allow egress from pods or workers, depending on the selected network mode:
    ```
    Protocol: TCP
    Destination: 0.0.0.0/0
    Ports: 443
    ```
-3. For non-OCI registries, verify Hub NAT Gateway is working
+4. For non-OCI registries, verify NAT Gateway egress is working
 
 ### Issue: Configuration Key Not Found <!-- omit from toc -->
 
@@ -638,6 +659,7 @@ terraform destroy
 - [OneOE Blueprint](https://github.com/oracle-quickstart/terraform-oci-open-lz/tree/master/blueprints/one-oe)
 - [OKE Documentation](https://docs.oracle.com/en-us/iaas/Content/ContEng/home.htm)
 - [VCN-Native Pod Networking](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking_topic-OCI_CNI_plugin.htm)
+- [Flannel Pod Networking](https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengpodnetworking_topic-flannel_CNI_plugin.htm)
 - [Hub-and-Spoke Network Topology](https://docs.oracle.com/en/solutions/hub-spoke-network/index.html)
 
 &nbsp;


### PR DESCRIPTION
Add native and overlay CNI validation for oke_simple, defaulting cni and pods_cidr from the selected network shape.

Omit pod subnet, route table, security list, pod NSG, and worker pod networking fields for overlay clusters while preserving native defaults.

Keep OKE route tables scoped to the current platform context so multiple OKE VCNs do not reference gateways from another OKE VCN.

Add Jsonnet fixtures for overlay output, invalid CNI combinations, overlay subnet validation, and ICMP security-list behavior.

Document OKE config-driven generation, native versus overlay modes, and the difference between oke_simple and published deployment paths.